### PR TITLE
Fix item fetch by using underscore parameters

### DIFF
--- a/fetch_items.py
+++ b/fetch_items.py
@@ -45,8 +45,8 @@ def fetch_all_item_ids(region="us", namespace="static-classic-us", locale="en_US
         params = {
             'namespace': namespace,
             'locale': locale,
-            'page': page,
-            'pageSize': page_size,
+            '_page': page,
+            '_pageSize': page_size,
             'orderby': 'id',
         }
         url = f'https://{region}.api.blizzard.com/data/wow/search/item'


### PR DESCRIPTION
## Summary
- adjust paging parameters in `fetch_items.py` to use `_page` and `_pageSize`

## Testing
- `python3 fetch_items.py | head`
- `sqlite3 items.db 'select count(*) from items;'`

------
https://chatgpt.com/codex/tasks/task_e_68826a0ea1848328ad35a8fe6dd9a89a