### PR TITLE
Add Classic Era namespace support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ export BLIZZARD_CLIENT_ID="111c95f387d14e02b43c751d9187000d"
 export BLIZZARD_CLIENT_SECRET="0WbrQzxKQA5r3WgpiZwCqz85vD8lGDeH"
 ```
 
-Run the script:
+Run the script (by default it fetches Cataclysm Classic data):
 
 ```
 python3 fetch_items.py
 ```
 
-The script will create `items.db` containing an `items` table with all fetched item IDs.
+To fetch Classic Era data pass the Classic Era namespace:
+
+```
+python3 fetch_items.py --namespace static-classic1x-us
+```
+
+The script will create `items.db` (or the path you provide via `--db-path`) containing an `items` table with all fetched item IDs.

--- a/fetch_items.py
+++ b/fetch_items.py
@@ -2,6 +2,7 @@ import os
 import re
 import requests
 import sqlite3
+import argparse
 
 CLIENT_ID = os.getenv('BLIZZARD_CLIENT_ID', '111c95f387d14e02b43c751d9187000d')
 CLIENT_SECRET = os.getenv('BLIZZARD_CLIENT_SECRET', '0WbrQzxKQA5r3WgpiZwCqz85vD8lGDeH')
@@ -18,26 +19,26 @@ def get_access_token():
     return resp.json()['access_token']
 
 
-def _auto_namespace(region: str, locale: str, token: str) -> str:
+def _auto_namespace(base_namespace: str, region: str, locale: str, token: str) -> str:
     """Detect the full static namespace with patch version."""
     url = f"https://{region}.api.blizzard.com/data/wow/item-class/index"
     headers = {"Authorization": f"Bearer {token}"}
     resp = requests.get(
         url,
-        params={"namespace": "static-classic-us", "locale": locale},
+        params={"namespace": base_namespace, "locale": locale},
         headers=headers,
         timeout=30,
     )
     resp.raise_for_status()
     href = resp.json().get("_links", {}).get("self", {}).get("href", "")
     match = re.search(r"namespace=([^&]+)", href)
-    return match.group(1) if match else "static-classic-us"
+    return match.group(1) if match else base_namespace
 
 
 def fetch_all_item_ids(region="us", namespace="static-classic-us", locale="en_US", page_size=1000):
     token = get_access_token()
-    if namespace == "static-classic-us":
-        namespace = _auto_namespace(region, locale, token)
+    if namespace in ("static-classic-us", "static-classic1x-us"):
+        namespace = _auto_namespace(namespace, region, locale, token)
     item_ids = []
     page = 1
     headers = {"Authorization": f"Bearer {token}"}
@@ -75,9 +76,24 @@ def store_in_db(item_ids, db_path='items.db'):
 
 
 def main():
-    ids = fetch_all_item_ids()
-    store_in_db(ids)
-    print(f'Stored {len(ids)} items in the database.')
+    parser = argparse.ArgumentParser(description="Fetch WoW item IDs")
+    parser.add_argument("--region", default="us", help="API region")
+    parser.add_argument(
+        "--namespace",
+        default="static-classic-us",
+        help="Static namespace, e.g. static-classic-us or static-classic1x-us",
+    )
+    parser.add_argument("--locale", default="en_US", help="Locale")
+    parser.add_argument(
+        "--db-path", default="items.db", help="Path to output SQLite database"
+    )
+    args = parser.parse_args()
+
+    ids = fetch_all_item_ids(
+        region=args.region, namespace=args.namespace, locale=args.locale
+    )
+    store_in_db(ids, db_path=args.db_path)
+    print(f"Stored {len(ids)} items in the database.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- allow specifying namespace/region/locale/db-path on CLI
- autodetect patch version for both `static-classic` and `static-classic1x`
- document how to fetch Classic Era data

## Testing
- `python3 fetch_items.py --db-path cat.db`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827e942f5c83289ccd72e77bf577d7