### PR TITLE
Add item database and DPS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,27 @@ the window when you click **Calculate**:
 ```bash
 python3 dps_gui.py
 ```
+
+## Item Database
+
+Items can be stored in a small SQLite database. Use `item_manager.py` to
+initialize the database and insert items. Stats are provided as a JSON
+object where keys match the fields used in `WarriorStats` (e.g. `attack_power`,
+`hit`, `base_damage_mh`).
+
+Create the database and add an item:
+
+```bash
+python3 item_manager.py --init-db
+python3 item_manager.py --add "Fiery Axe" weapon_mh '{"base_damage_mh": 100, "base_speed_mh": 3.6}' 60
+```
+
+Once items are stored you can perform DPS calculations using their stats with
+`dps_with_items.py`:
+
+```bash
+python3 dps_with_items.py --items "Fiery Axe" --weapon-skill 300
+```
+
+This script loads the specified items, merges their stats and passes them to
+`dps_calculator.py`.

--- a/dps_with_items.py
+++ b/dps_with_items.py
@@ -1,0 +1,59 @@
+import argparse
+from typing import Dict
+from item_database import get_items
+from dps_calculator import calculate_dps, WarriorStats
+
+
+def merge_stats(base: Dict[str, float], item_stats: Dict[str, float]) -> None:
+    for k, v in item_stats.items():
+        base[k] = base.get(k, 0) + v
+
+
+def build_stats(args: argparse.Namespace) -> WarriorStats:
+    items = get_items(args.items)
+    stats_dict: Dict[str, float] = {
+        "player_level": args.player_level,
+        "target_level": args.target_level,
+        "weapon_skill": args.weapon_skill,
+        "attack_power": 0,
+        "hit": 0,
+        "spellbook_crit": 0,
+        "aura_crit": 0,
+        "base_damage_mh": 0,
+        "base_speed_mh": 0,
+        "base_damage_oh": 0,
+        "base_speed_oh": 0,
+        "dual_wield_spec": args.dual_wield_spec,
+        "impale": args.impale,
+        "target_armor": args.target_armor,
+        "target_block_value": args.target_block_value,
+    }
+
+    for item in items:
+        merge_stats(stats_dict, item.stats)
+
+    return WarriorStats(**stats_dict)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Calculate DPS using items from the database")
+    p.add_argument("--player-level", type=int, default=60)
+    p.add_argument("--target-level", type=int, default=63)
+    p.add_argument("--weapon-skill", type=int, default=300)
+    p.add_argument("--items", nargs="*", default=[], help="Item names to equip")
+    p.add_argument("--dual-wield-spec", type=int, default=0)
+    p.add_argument("--impale", type=int, default=0)
+    p.add_argument("--target-armor", type=int, default=0)
+    p.add_argument("--target-block-value", type=float, default=45.0)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    stats = build_stats(args)
+    dps = calculate_dps(stats)
+    print(f"Estimated DPS: {dps:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/item_database.py
+++ b/item_database.py
@@ -1,0 +1,63 @@
+import sqlite3
+import json
+from dataclasses import dataclass
+from typing import Dict, List
+
+DB_PATH = "items.db"
+
+
+def init_db(db_path: str = DB_PATH) -> None:
+    """Create the items table if it does not exist."""
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS items (
+            name TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            required_level INTEGER NOT NULL,
+            stats TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+@dataclass
+class Item:
+    name: str
+    type: str
+    required_level: int
+    stats: Dict[str, float]
+
+
+def add_item(item: Item, db_path: str = DB_PATH) -> None:
+    """Insert an item into the database."""
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute(
+        "INSERT OR REPLACE INTO items (name, type, required_level, stats) VALUES (?, ?, ?, ?)",
+        (item.name, item.type, item.required_level, json.dumps(item.stats)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_items(names: List[str], db_path: str = DB_PATH) -> List[Item]:
+    """Retrieve items by name."""
+    if not names:
+        return []
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    placeholders = ",".join("?" for _ in names)
+    c.execute(
+        f"SELECT name, type, required_level, stats FROM items WHERE name IN ({placeholders})",
+        names,
+    )
+    rows = c.fetchall()
+    conn.close()
+    items = []
+    for name, type_, level, stats_json in rows:
+        items.append(Item(name=name, type=type_, required_level=level, stats=json.loads(stats_json)))
+    return items

--- a/item_manager.py
+++ b/item_manager.py
@@ -1,0 +1,30 @@
+import argparse
+import json
+from item_database import init_db, add_item, Item
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage the items database")
+    parser.add_argument("--init-db", action="store_true", help="Initialize database")
+    parser.add_argument(
+        "--add",
+        nargs=4,
+        metavar=("NAME", "TYPE", "STATS_JSON", "LEVEL"),
+        help="Add an item as JSON stats"
+    )
+
+    args = parser.parse_args()
+
+    if args.init_db:
+        init_db()
+        print("Database initialized")
+
+    if args.add:
+        name, type_, stats_json, level = args.add
+        stats = json.loads(stats_json)
+        add_item(Item(name=name, type=type_, required_level=int(level), stats=stats))
+        print(f"Inserted {name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add SQLite-based item database utilities
- allow inserting items via `item_manager.py`
- calculate DPS with stored items using `dps_with_items.py`
- document usage in README

## Testing
- `python3 item_manager.py --init-db`
- `python3 item_manager.py --add "Fiery Axe" weapon_mh '{"base_damage_mh": 50, "base_speed_mh": 2.5, "attack_power": 20}' 40`
- `python3 dps_with_items.py --items "Fiery Axe" --weapon-skill 300`
- `python3 -m py_compile dps_calculator.py dps_gui.py item_database.py item_manager.py dps_with_items.py`


------
https://chatgpt.com/codex/tasks/task_e_6884ba9d9f008328a13f7b1f1644a2a6