### PR TITLE
Add GUIs for item management and DPS with items

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ the window when you click **Calculate**:
 python3 dps_gui.py
 ```
 
+GUIs are also provided for the item manager and for calculating DPS using items.
+
+Run `item_manager_gui.py` to initialize the database or insert items through a
+simple form, and `dps_with_items_gui.py` to calculate DPS using equipment from
+the database.
+
+```bash
+python3 item_manager_gui.py
+python3 dps_with_items_gui.py
+```
+
 ## Item Database
 
 Items can be stored in a small SQLite database. Use `item_manager.py` to

--- a/dps_gui.py
+++ b/dps_gui.py
@@ -3,87 +3,95 @@ from tkinter import ttk
 from dps_calculator import WarriorStats, calculate_dps
 
 
-def compute():
-    try:
-        stats = WarriorStats(
-            player_level=int(player_level_var.get() or 60),
-            target_level=int(target_level_var.get() or 63),
-            weapon_skill=int(weapon_skill_var.get() or 300),
-            base_damage_mh=float(base_damage_mh_var.get() or 0),
-            base_speed_mh=float(base_speed_mh_var.get() or 0),
-            attack_power=float(attack_power_var.get() or 0),
-            hit=float(hit_var.get() or 0),
-            spellbook_crit=float(crit_var.get() or 0),
-            aura_crit=float(aura_crit_var.get() or 0),
-            base_damage_oh=float(base_damage_oh_var.get() or 0),
-            base_speed_oh=float(base_speed_oh_var.get() or 0),
-            dual_wield_spec=int(dual_wield_spec_var.get() or 0),
-            impale=int(impale_var.get() or 0),
-            target_armor=int(target_armor_var.get() or 0),
-            target_block_value=float(target_block_value_var.get() or 45.0),
-        )
-        dps = calculate_dps(stats)
-        result_var.set(f"Estimated DPS: {dps:.2f}")
-    except ValueError:
-        result_var.set("Invalid input")
+def main() -> None:
+    def compute():
+        try:
+            stats = WarriorStats(
+                player_level=int(player_level_var.get() or 60),
+                target_level=int(target_level_var.get() or 63),
+                weapon_skill=int(weapon_skill_var.get() or 300),
+                base_damage_mh=float(base_damage_mh_var.get() or 0),
+                base_speed_mh=float(base_speed_mh_var.get() or 0),
+                attack_power=float(attack_power_var.get() or 0),
+                hit=float(hit_var.get() or 0),
+                spellbook_crit=float(crit_var.get() or 0),
+                aura_crit=float(aura_crit_var.get() or 0),
+                base_damage_oh=float(base_damage_oh_var.get() or 0),
+                base_speed_oh=float(base_speed_oh_var.get() or 0),
+                dual_wield_spec=int(dual_wield_spec_var.get() or 0),
+                impale=int(impale_var.get() or 0),
+                target_armor=int(target_armor_var.get() or 0),
+                target_block_value=float(target_block_value_var.get() or 45.0),
+            )
+            dps = calculate_dps(stats)
+            result_var.set(f"Estimated DPS: {dps:.2f}")
+        except ValueError:
+            result_var.set("Invalid input")
+
+    root = tk.Tk()
+    root.title("DPS Calculator")
+
+    mainframe = ttk.Frame(root, padding="10")
+    mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+
+    global player_level_var, target_level_var, weapon_skill_var
+    global base_damage_mh_var, base_speed_mh_var, attack_power_var
+    global hit_var, crit_var, aura_crit_var
+    global base_damage_oh_var, base_speed_oh_var
+    global dual_wield_spec_var, impale_var
+    global target_armor_var, target_block_value_var
+    global result_var
+
+    player_level_var = tk.StringVar(value="60")
+    target_level_var = tk.StringVar(value="63")
+    weapon_skill_var = tk.StringVar(value="300")
+    base_damage_mh_var = tk.StringVar()
+    base_speed_mh_var = tk.StringVar()
+    attack_power_var = tk.StringVar()
+    hit_var = tk.StringVar(value="0")
+    crit_var = tk.StringVar(value="0")
+    aura_crit_var = tk.StringVar(value="0")
+    base_damage_oh_var = tk.StringVar(value="0")
+    base_speed_oh_var = tk.StringVar(value="0")
+    dual_wield_spec_var = tk.StringVar(value="0")
+    impale_var = tk.StringVar(value="0")
+    target_armor_var = tk.StringVar(value="0")
+    target_block_value_var = tk.StringVar(value="45.0")
+    result_var = tk.StringVar(value="")
+
+    fields = [
+        ("Player Level", player_level_var),
+        ("Target Level", target_level_var),
+        ("Weapon Skill", weapon_skill_var),
+        ("Base Damage MH", base_damage_mh_var),
+        ("Base Speed MH", base_speed_mh_var),
+        ("Attack Power", attack_power_var),
+        ("Hit %", hit_var),
+        ("Crit %", crit_var),
+        ("Aura Crit %", aura_crit_var),
+        ("Base Damage OH", base_damage_oh_var),
+        ("Base Speed OH", base_speed_oh_var),
+        ("Dual Wield Spec", dual_wield_spec_var),
+        ("Impale", impale_var),
+        ("Target Armor", target_armor_var),
+        ("Target Block Value", target_block_value_var),
+    ]
+
+    for i, (label, var) in enumerate(fields):
+        ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
+        ttk.Entry(mainframe, textvariable=var).grid(column=1, row=i, sticky=(tk.W, tk.E))
+
+    compute_button = ttk.Button(mainframe, text="Calculate", command=compute)
+    compute_button.grid(column=0, row=len(fields), columnspan=2, pady=(5, 0))
+
+    result_label = ttk.Label(mainframe, textvariable=result_var, font=("Helvetica", 12))
+    result_label.grid(column=0, row=len(fields)+1, columnspan=2, pady=(5, 0))
+
+    for child in mainframe.winfo_children():
+        child.grid_configure(padx=5, pady=2)
+
+    root.mainloop()
 
 
-root = tk.Tk()
-root.title("DPS Calculator")
-
-mainframe = ttk.Frame(root, padding="10")
-mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
-
-# Variables
-player_level_var = tk.StringVar(value="60")
-target_level_var = tk.StringVar(value="63")
-weapon_skill_var = tk.StringVar(value="300")
-base_damage_mh_var = tk.StringVar()
-base_speed_mh_var = tk.StringVar()
-attack_power_var = tk.StringVar()
-hit_var = tk.StringVar(value="0")
-crit_var = tk.StringVar(value="0")
-aura_crit_var = tk.StringVar(value="0")
-base_damage_oh_var = tk.StringVar(value="0")
-base_speed_oh_var = tk.StringVar(value="0")
-dual_wield_spec_var = tk.StringVar(value="0")
-impale_var = tk.StringVar(value="0")
-
-# Target armor and block value
-target_armor_var = tk.StringVar(value="0")
-target_block_value_var = tk.StringVar(value="45.0")
-
-result_var = tk.StringVar(value="")
-
-fields = [
-    ("Player Level", player_level_var),
-    ("Target Level", target_level_var),
-    ("Weapon Skill", weapon_skill_var),
-    ("Base Damage MH", base_damage_mh_var),
-    ("Base Speed MH", base_speed_mh_var),
-    ("Attack Power", attack_power_var),
-    ("Hit %", hit_var),
-    ("Crit %", crit_var),
-    ("Aura Crit %", aura_crit_var),
-    ("Base Damage OH", base_damage_oh_var),
-    ("Base Speed OH", base_speed_oh_var),
-    ("Dual Wield Spec", dual_wield_spec_var),
-    ("Impale", impale_var),
-    ("Target Armor", target_armor_var),
-    ("Target Block Value", target_block_value_var),
-]
-
-for i, (label, var) in enumerate(fields):
-    ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
-    ttk.Entry(mainframe, textvariable=var).grid(column=1, row=i, sticky=(tk.W, tk.E))
-
-compute_button = ttk.Button(mainframe, text="Calculate", command=compute)
-compute_button.grid(column=0, row=len(fields), columnspan=2, pady=(5, 0))
-
-result_label = ttk.Label(mainframe, textvariable=result_var, font=("Helvetica", 12))
-result_label.grid(column=0, row=len(fields)+1, columnspan=2, pady=(5, 0))
-
-for child in mainframe.winfo_children():
-    child.grid_configure(padx=5, pady=2)
-
-root.mainloop()
+if __name__ == "__main__":
+    main()

--- a/dps_with_items_gui.py
+++ b/dps_with_items_gui.py
@@ -1,0 +1,68 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+import argparse
+from dps_with_items import build_stats
+from dps_calculator import calculate_dps
+
+
+def compute():
+    try:
+        items = [name.strip() for name in items_var.get().split(',') if name.strip()]
+        args = argparse.Namespace(
+            player_level=int(player_level_var.get() or 60),
+            target_level=int(target_level_var.get() or 63),
+            weapon_skill=int(weapon_skill_var.get() or 300),
+            items=items,
+            dual_wield_spec=int(dual_wield_spec_var.get() or 0),
+            impale=int(impale_var.get() or 0),
+            target_armor=int(target_armor_var.get() or 0),
+            target_block_value=float(target_block_value_var.get() or 45.0),
+        )
+        stats = build_stats(args)
+        dps = calculate_dps(stats)
+        result_var.set(f"Estimated DPS: {dps:.2f}")
+    except Exception as e:
+        messagebox.showerror("Error", str(e))
+
+
+root = tk.Tk()
+root.title("DPS with Items")
+
+mainframe = ttk.Frame(root, padding="10")
+mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+
+player_level_var = tk.StringVar(value="60")
+target_level_var = tk.StringVar(value="63")
+weapon_skill_var = tk.StringVar(value="300")
+items_var = tk.StringVar()
+dual_wield_spec_var = tk.StringVar(value="0")
+impale_var = tk.StringVar(value="0")
+target_armor_var = tk.StringVar(value="0")
+target_block_value_var = tk.StringVar(value="45.0")
+result_var = tk.StringVar()
+
+fields = [
+    ("Player Level", player_level_var),
+    ("Target Level", target_level_var),
+    ("Weapon Skill", weapon_skill_var),
+    ("Items (comma separated)", items_var),
+    ("Dual Wield Spec", dual_wield_spec_var),
+    ("Impale", impale_var),
+    ("Target Armor", target_armor_var),
+    ("Target Block Value", target_block_value_var),
+]
+
+for i, (label, var) in enumerate(fields):
+    ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
+    ttk.Entry(mainframe, textvariable=var).grid(column=1, row=i, sticky=(tk.W, tk.E))
+
+compute_button = ttk.Button(mainframe, text="Calculate", command=compute)
+compute_button.grid(column=0, row=len(fields), columnspan=2, pady=(5, 0))
+
+result_label = ttk.Label(mainframe, textvariable=result_var, font=("Helvetica", 12))
+result_label.grid(column=0, row=len(fields)+1, columnspan=2, pady=(5, 0))
+
+for child in mainframe.winfo_children():
+    child.grid_configure(padx=5, pady=2)
+
+root.mainloop()

--- a/item_manager_gui.py
+++ b/item_manager_gui.py
@@ -1,0 +1,55 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+import json
+from item_database import init_db, add_item, Item
+
+
+def init_db_action():
+    init_db()
+    messagebox.showinfo("Success", "Database initialized")
+
+
+def add_item_action():
+    try:
+        name = name_var.get()
+        type_ = type_var.get()
+        stats = json.loads(stats_var.get())
+        level = int(level_var.get())
+        add_item(Item(name=name, type=type_, required_level=level, stats=stats))
+        messagebox.showinfo("Success", f"Inserted {name}")
+    except Exception as e:
+        messagebox.showerror("Error", str(e))
+
+
+root = tk.Tk()
+root.title("Item Manager")
+
+mainframe = ttk.Frame(root, padding="10")
+mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
+
+name_var = tk.StringVar()
+type_var = tk.StringVar()
+stats_var = tk.StringVar()
+level_var = tk.StringVar(value="0")
+
+fields = [
+    ("Name", name_var),
+    ("Type", type_var),
+    ("Stats JSON", stats_var),
+    ("Required Level", level_var),
+]
+
+for i, (label, var) in enumerate(fields):
+    ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
+    ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
+
+init_button = ttk.Button(mainframe, text="Initialize DB", command=init_db_action)
+init_button.grid(column=0, row=len(fields), pady=(5, 0))
+
+add_button = ttk.Button(mainframe, text="Add Item", command=add_item_action)
+add_button.grid(column=1, row=len(fields), pady=(5, 0))
+
+for child in mainframe.winfo_children():
+    child.grid_configure(padx=5, pady=2)
+
+root.mainloop()


### PR DESCRIPTION
## Summary
- refactor `dps_gui.py` so it can be imported and launched via a `main()` function
- add new Tkinter GUIs `item_manager_gui.py` and `dps_with_items_gui.py`
- mention the new GUIs in the README

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6885459ccc6c8328811dcffa6c777f5c