### PR TITLE
Improve item manager interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,17 @@ python3 dps_with_items_gui.py
 ## Item Database
 
 Items can be stored in a small SQLite database. Use `item_manager.py` to
-initialize the database and insert items. Stats are provided as a JSON
-object where keys match the fields used in `WarriorStats` (e.g. `attack_power`,
-`hit`, `base_damage_mh`).
+initialize the database and insert items. Stats are provided as simple
+`key=value` pairs instead of a JSON blob for ease of use. Keys correspond to
+the fields used in `WarriorStats` (e.g. `attack_power`, `hit`,
+`base_damage_mh`).
 
 Create the database and add an item:
 
 ```bash
 python3 item_manager.py --init-db
-python3 item_manager.py --add "Fiery Axe" weapon_mh '{"base_damage_mh": 100, "base_speed_mh": 3.6}' 60
+python3 item_manager.py --add "Fiery Axe" weapon_mh 60 \
+  --stat base_damage_mh=100 --stat base_speed_mh=3.6
 ```
 
 Once items are stored you can perform DPS calculations using their stats with

--- a/item_manager.py
+++ b/item_manager.py
@@ -1,6 +1,18 @@
 import argparse
-import json
 from item_database import init_db, add_item, Item
+
+
+def parse_stat_pairs(pairs):
+    stats = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise argparse.ArgumentTypeError(f"Invalid stat format: {pair}")
+        key, value = pair.split("=", 1)
+        try:
+            stats[key] = float(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"Value for {key} must be numeric")
+    return stats
 
 
 def main() -> None:
@@ -8,9 +20,17 @@ def main() -> None:
     parser.add_argument("--init-db", action="store_true", help="Initialize database")
     parser.add_argument(
         "--add",
-        nargs=4,
-        metavar=("NAME", "TYPE", "STATS_JSON", "LEVEL"),
-        help="Add an item as JSON stats"
+        nargs=3,
+        metavar=("NAME", "TYPE", "LEVEL"),
+        help="Add an item with stats"
+    )
+    parser.add_argument(
+        "--stat",
+        dest="stats",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Stat pair, may be used multiple times",
     )
 
     args = parser.parse_args()
@@ -20,8 +40,8 @@ def main() -> None:
         print("Database initialized")
 
     if args.add:
-        name, type_, stats_json, level = args.add
-        stats = json.loads(stats_json)
+        name, type_, level = args.add
+        stats = parse_stat_pairs(args.stats)
         add_item(Item(name=name, type=type_, required_level=int(level), stats=stats))
         print(f"Inserted {name}")
 

--- a/item_manager_gui.py
+++ b/item_manager_gui.py
@@ -1,6 +1,6 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
-import json
+from typing import Dict
 from item_database import init_db, add_item, Item
 
 
@@ -9,14 +9,30 @@ def init_db_action():
     messagebox.showinfo("Success", "Database initialized")
 
 
+stats: Dict[str, float] = {}
+
+
+def add_stat_action():
+    try:
+        key = stat_key_var.get()
+        value = float(stat_value_var.get())
+        stats[key] = value
+        stats_list_var.set(", ".join(f"{k}={v}" for k, v in stats.items()))
+        stat_key_var.set("")
+        stat_value_var.set("")
+    except ValueError:
+        messagebox.showerror("Error", "Value must be numeric")
+
+
 def add_item_action():
     try:
         name = name_var.get()
         type_ = type_var.get()
-        stats = json.loads(stats_var.get())
         level = int(level_var.get())
         add_item(Item(name=name, type=type_, required_level=level, stats=stats))
         messagebox.showinfo("Success", f"Inserted {name}")
+        stats.clear()
+        stats_list_var.set("")
     except Exception as e:
         messagebox.showerror("Error", str(e))
 
@@ -29,13 +45,16 @@ mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
 
 name_var = tk.StringVar()
 type_var = tk.StringVar()
-stats_var = tk.StringVar()
+stat_key_var = tk.StringVar()
+stat_value_var = tk.StringVar()
+stats_list_var = tk.StringVar()
 level_var = tk.StringVar(value="0")
 
 fields = [
     ("Name", name_var),
     ("Type", type_var),
-    ("Stats JSON", stats_var),
+    ("Stat Key", stat_key_var),
+    ("Stat Value", stat_value_var),
     ("Required Level", level_var),
 ]
 
@@ -43,11 +62,17 @@ for i, (label, var) in enumerate(fields):
     ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
     ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
 
+stats_label = ttk.Label(mainframe, textvariable=stats_list_var)
+stats_label.grid(column=0, row=len(fields), columnspan=2, sticky=(tk.W))
+
+add_stat_button = ttk.Button(mainframe, text="Add Stat", command=add_stat_action)
+add_stat_button.grid(column=0, row=len(fields)+1, pady=(5, 0))
+
 init_button = ttk.Button(mainframe, text="Initialize DB", command=init_db_action)
-init_button.grid(column=0, row=len(fields), pady=(5, 0))
+init_button.grid(column=1, row=len(fields)+1, pady=(5, 0))
 
 add_button = ttk.Button(mainframe, text="Add Item", command=add_item_action)
-add_button.grid(column=1, row=len(fields), pady=(5, 0))
+add_button.grid(column=1, row=len(fields)+2, pady=(5, 0))
 
 for child in mainframe.winfo_children():
     child.grid_configure(padx=5, pady=2)


### PR DESCRIPTION
## Summary
- simplify item database management
- add `--stat` CLI options instead of JSON
- update GUI with individual stat fields
- update README with new instructions

## Testing
- `python3 -m py_compile dps_calculator.py dps_gui.py dps_with_items.py dps_with_items_gui.py item_database.py item_manager.py item_manager_gui.py`
- `python3 item_manager.py --init-db`
- `python3 item_manager.py --add "Fiery Axe" weapon_mh 60 --stat base_damage_mh=100 --stat base_speed_mh=3.6`
- `python3 dps_with_items.py --items "Fiery Axe" --weapon-skill 300`


------
https://chatgpt.com/codex/tasks/task_e_6885efe5650483288f72540e7e8f48f4