### PR TITLE
Improve stats entry UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ GUIs are also provided for the item manager and for calculating DPS using items.
 
 Run `item_manager_gui.py` to initialize the database or insert items through a
 simple form, and `dps_with_items_gui.py` to calculate DPS using equipment from
-the database.
+the database. The item manager GUI now provides a drop-down list of available
+stat keys for convenience.
 
 ```bash
 python3 item_manager_gui.py
@@ -48,7 +49,8 @@ Items can be stored in a small SQLite database. Use `item_manager.py` to
 initialize the database and insert items. Stats are provided as simple
 `key=value` pairs instead of a JSON blob for ease of use. Keys correspond to
 the fields used in `WarriorStats` (e.g. `attack_power`, `hit`,
-`base_damage_mh`).
+`base_damage_mh`). Run `item_manager.py --list-stats` to see all supported
+stat keys.
 
 Create the database and add an item:
 

--- a/item_manager.py
+++ b/item_manager.py
@@ -1,5 +1,21 @@
 import argparse
+from typing import List
 from item_database import init_db, add_item, Item
+
+# Common stat keys that can be stored for an item. These correspond to fields
+# used in `WarriorStats` and can be referenced later when calculating DPS.
+STAT_KEYS: List[str] = [
+    "attack_power",
+    "hit",
+    "spellbook_crit",
+    "aura_crit",
+    "base_damage_mh",
+    "base_speed_mh",
+    "base_damage_oh",
+    "base_speed_oh",
+    "dual_wield_spec",
+    "impale",
+]
 
 
 def parse_stat_pairs(pairs):
@@ -8,6 +24,10 @@ def parse_stat_pairs(pairs):
         if "=" not in pair:
             raise argparse.ArgumentTypeError(f"Invalid stat format: {pair}")
         key, value = pair.split("=", 1)
+        if key not in STAT_KEYS:
+            raise argparse.ArgumentTypeError(
+                f"Unknown stat '{key}'. Use --list-stats to see valid options"
+            )
         try:
             stats[key] = float(value)
         except ValueError:
@@ -18,6 +38,11 @@ def parse_stat_pairs(pairs):
 def main() -> None:
     parser = argparse.ArgumentParser(description="Manage the items database")
     parser.add_argument("--init-db", action="store_true", help="Initialize database")
+    parser.add_argument(
+        "--list-stats",
+        action="store_true",
+        help="Print available stat keys and exit",
+    )
     parser.add_argument(
         "--add",
         nargs=3,
@@ -38,6 +63,11 @@ def main() -> None:
     if args.init_db:
         init_db()
         print("Database initialized")
+
+    if args.list_stats:
+        for key in STAT_KEYS:
+            print(key)
+        return
 
     if args.add:
         name, type_, level = args.add

--- a/item_manager_gui.py
+++ b/item_manager_gui.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from typing import Dict
 from item_database import init_db, add_item, Item
+from item_manager import STAT_KEYS
 
 
 def init_db_action():
@@ -60,7 +61,12 @@ fields = [
 
 for i, (label, var) in enumerate(fields):
     ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
-    ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
+    if var is stat_key_var:
+        ttk.Combobox(mainframe, textvariable=var, values=STAT_KEYS, width=37).grid(
+            column=1, row=i, sticky=(tk.W, tk.E)
+        )
+    else:
+        ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
 
 stats_label = ttk.Label(mainframe, textvariable=stats_list_var)
 stats_label.grid(column=0, row=len(fields), columnspan=2, sticky=(tk.W))


### PR DESCRIPTION
## Summary
- show available stat keys in README
- validate stat keys and list them via `--list-stats`
- enhance item manager GUI with a drop-down for stats

## Testing
- `python3 -m py_compile item_manager.py item_manager_gui.py`
- `python3 item_manager.py --list-stats`

------
https://chatgpt.com/codex/tasks/task_e_6885f27804dc8328a6294988d22cf9ea