### PR TITLE
Refactor item manager form

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ GUIs are also provided for the item manager and for calculating DPS using items.
 
 Run `item_manager_gui.py` to initialize the database or insert items through a
 simple form, and `dps_with_items_gui.py` to calculate DPS using equipment from
-the database. The item manager GUI now provides a drop-down list of available
-stat keys for convenience.
+the database. The item manager GUI now provides a separate input field for each
+stat instead of a drop-down list.
 
 ```bash
 python3 item_manager_gui.py

--- a/item_manager_gui.py
+++ b/item_manager_gui.py
@@ -1,6 +1,5 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
-from typing import Dict
 from item_database import init_db, add_item, Item
 from item_manager import STAT_KEYS
 
@@ -10,30 +9,22 @@ def init_db_action():
     messagebox.showinfo("Success", "Database initialized")
 
 
-stats: Dict[str, float] = {}
-
-
-def add_stat_action():
-    try:
-        key = stat_key_var.get()
-        value = float(stat_value_var.get())
-        stats[key] = value
-        stats_list_var.set(", ".join(f"{k}={v}" for k, v in stats.items()))
-        stat_key_var.set("")
-        stat_value_var.set("")
-    except ValueError:
-        messagebox.showerror("Error", "Value must be numeric")
-
-
 def add_item_action():
     try:
         name = name_var.get()
         type_ = type_var.get()
         level = int(level_var.get())
+        stats = {}
+        for key, var in stat_vars.items():
+            value = var.get().strip()
+            if value:
+                stats[key] = float(value)
         add_item(Item(name=name, type=type_, required_level=level, stats=stats))
         messagebox.showinfo("Success", f"Inserted {name}")
-        stats.clear()
-        stats_list_var.set("")
+        for var in stat_vars.values():
+            var.set("")
+    except ValueError:
+        messagebox.showerror("Error", "Stat values must be numeric")
     except Exception as e:
         messagebox.showerror("Error", str(e))
 
@@ -46,39 +37,26 @@ mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
 
 name_var = tk.StringVar()
 type_var = tk.StringVar()
-stat_key_var = tk.StringVar()
-stat_value_var = tk.StringVar()
-stats_list_var = tk.StringVar()
 level_var = tk.StringVar(value="0")
+
+stat_vars = {key: tk.StringVar() for key in STAT_KEYS}
 
 fields = [
     ("Name", name_var),
     ("Type", type_var),
-    ("Stat Key", stat_key_var),
-    ("Stat Value", stat_value_var),
     ("Required Level", level_var),
 ]
+fields += [(key, stat_vars[key]) for key in STAT_KEYS]
 
 for i, (label, var) in enumerate(fields):
     ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
-    if var is stat_key_var:
-        ttk.Combobox(mainframe, textvariable=var, values=STAT_KEYS, width=37).grid(
-            column=1, row=i, sticky=(tk.W, tk.E)
-        )
-    else:
-        ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
-
-stats_label = ttk.Label(mainframe, textvariable=stats_list_var)
-stats_label.grid(column=0, row=len(fields), columnspan=2, sticky=(tk.W))
-
-add_stat_button = ttk.Button(mainframe, text="Add Stat", command=add_stat_action)
-add_stat_button.grid(column=0, row=len(fields)+1, pady=(5, 0))
+    ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
 
 init_button = ttk.Button(mainframe, text="Initialize DB", command=init_db_action)
-init_button.grid(column=1, row=len(fields)+1, pady=(5, 0))
+init_button.grid(column=0, row=len(fields), pady=(5, 0))
 
 add_button = ttk.Button(mainframe, text="Add Item", command=add_item_action)
-add_button.grid(column=1, row=len(fields)+2, pady=(5, 0))
+add_button.grid(column=1, row=len(fields), pady=(5, 0))
 
 for child in mainframe.winfo_children():
     child.grid_configure(padx=5, pady=2)


### PR DESCRIPTION
## Summary
- provide a text field for every stat in the item manager GUI
- update README to reflect the simplified form

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68862192d3848328a9cf4f9d974f3b04