### PR TITLE
Add GUI item selectors

### DIFF
--- a/dps_with_items_gui.py
+++ b/dps_with_items_gui.py
@@ -3,11 +3,12 @@ from tkinter import ttk, messagebox
 import argparse
 from dps_with_items import build_stats
 from dps_calculator import calculate_dps
+from item_database import list_item_names
 
 
 def compute():
     try:
-        items = [name.strip() for name in items_var.get().split(',') if name.strip()]
+        items = [var.get() for var in slot_vars.values() if var.get()]
         args = argparse.Namespace(
             player_level=int(player_level_var.get() or 60),
             target_level=int(target_level_var.get() or 63),
@@ -34,7 +35,6 @@ mainframe.grid(column=0, row=0, sticky=(tk.W, tk.E, tk.N, tk.S))
 player_level_var = tk.StringVar(value="60")
 target_level_var = tk.StringVar(value="63")
 weapon_skill_var = tk.StringVar(value="300")
-items_var = tk.StringVar()
 dual_wield_spec_var = tk.StringVar(value="0")
 impale_var = tk.StringVar(value="0")
 target_armor_var = tk.StringVar(value="0")
@@ -45,7 +45,6 @@ fields = [
     ("Player Level", player_level_var),
     ("Target Level", target_level_var),
     ("Weapon Skill", weapon_skill_var),
-    ("Items (comma separated)", items_var),
     ("Dual Wield Spec", dual_wield_spec_var),
     ("Impale", impale_var),
     ("Target Armor", target_armor_var),
@@ -55,6 +54,61 @@ fields = [
 for i, (label, var) in enumerate(fields):
     ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
     ttk.Entry(mainframe, textvariable=var).grid(column=1, row=i, sticky=(tk.W, tk.E))
+
+# Item selection
+slot_names = [
+    "Helm",
+    "Neck",
+    "Chest",
+    "Bracers",
+    "Hands",
+    "Belt",
+    "Legs",
+    "Boots",
+    "Ring 1",
+    "Ring 2",
+    "Trinket 1",
+    "Trinket 2",
+    "Main Hand",
+    "Off Hand",
+    "Ranged",
+    "Ammo",
+]
+slot_vars = {name: tk.StringVar() for name in slot_names}
+
+try:
+    all_items = list_item_names()
+except Exception:
+    all_items = []
+
+equip_frame = ttk.Frame(mainframe, padding="5")
+equip_frame.grid(column=2, row=0, rowspan=len(fields), padx=(20, 0))
+
+layout = {
+    "Helm": (0, 1),
+    "Neck": (1, 1),
+    "Ring 1": (1, 2),
+    "Bracers": (2, 0),
+    "Chest": (2, 1),
+    "Trinket 1": (2, 2),
+    "Hands": (3, 0),
+    "Belt": (3, 1),
+    "Ring 2": (3, 2),
+    "Main Hand": (3, 3),
+    "Legs": (4, 1),
+    "Trinket 2": (4, 2),
+    "Boots": (5, 1),
+    "Off Hand": (6, 3),
+    "Ranged": (7, 3),
+    "Ammo": (8, 3),
+}
+
+for name, var in slot_vars.items():
+    r, c = layout.get(name, (0, 0))
+    ttk.Label(equip_frame, text=name).grid(row=r * 2, column=c, sticky=tk.W)
+    ttk.Combobox(equip_frame, textvariable=var, values=all_items, width=20).grid(
+        row=r * 2 + 1, column=c, sticky=(tk.W, tk.E)
+    )
 
 compute_button = ttk.Button(mainframe, text="Calculate", command=compute)
 compute_button.grid(column=0, row=len(fields), columnspan=2, pady=(5, 0))

--- a/item_database.py
+++ b/item_database.py
@@ -61,3 +61,16 @@ def get_items(names: List[str], db_path: str = DB_PATH) -> List[Item]:
     for name, type_, level, stats_json in rows:
         items.append(Item(name=name, type=type_, required_level=level, stats=json.loads(stats_json)))
     return items
+
+
+def list_item_names(item_type: str | None = None, db_path: str = DB_PATH) -> List[str]:
+    """Return a list of item names, optionally filtered by type."""
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    if item_type is None:
+        c.execute("SELECT name FROM items")
+    else:
+        c.execute("SELECT name FROM items WHERE type = ?", (item_type,))
+    names = [row[0] for row in c.fetchall()]
+    conn.close()
+    return names


### PR DESCRIPTION
## Summary
- add function to list item names from the database
- overhaul items GUI to use dropdown selectors for each gear slot and show a character layout

## Testing
- `python3 -m py_compile dps_calculator.py dps_gui.py dps_with_items.py item_database.py item_manager.py item_manager_gui.py dps_with_items_gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688629ad5f9c832898670458687af15b