### PR TITLE
Add item type dropdown in manager GUI

### DIFF
--- a/item_manager.py
+++ b/item_manager.py
@@ -17,6 +17,26 @@ STAT_KEYS: List[str] = [
     "impale",
 ]
 
+# Predefined item types for each equipment slot. These strings are used when
+# inserting items through the GUI so users can pick a slot from a drop-down
+# rather than typing it manually.
+ITEM_TYPES: List[str] = [
+    "Helm",
+    "Neck",
+    "Chest",
+    "Bracers",
+    "Hands",
+    "Belt",
+    "Legs",
+    "Boots",
+    "Ring",
+    "Trinket",
+    "Main Hand",
+    "Off Hand",
+    "Ranged",
+    "Ammo",
+]
+
 
 def parse_stat_pairs(pairs):
     stats = {}

--- a/item_manager_gui.py
+++ b/item_manager_gui.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 from item_database import init_db, add_item, Item
-from item_manager import STAT_KEYS
+from item_manager import STAT_KEYS, ITEM_TYPES
 
 
 def init_db_action():
@@ -50,7 +50,14 @@ fields += [(key, stat_vars[key]) for key in STAT_KEYS]
 
 for i, (label, var) in enumerate(fields):
     ttk.Label(mainframe, text=label).grid(column=0, row=i, sticky=tk.W)
-    ttk.Entry(mainframe, textvariable=var, width=40).grid(column=1, row=i, sticky=(tk.W, tk.E))
+    if label == "Type":
+        ttk.Combobox(mainframe, textvariable=var, values=ITEM_TYPES, width=37).grid(
+            column=1, row=i, sticky=(tk.W, tk.E)
+        )
+    else:
+        ttk.Entry(mainframe, textvariable=var, width=40).grid(
+            column=1, row=i, sticky=(tk.W, tk.E)
+        )
 
 init_button = ttk.Button(mainframe, text="Initialize DB", command=init_db_action)
 init_button.grid(column=0, row=len(fields), pady=(5, 0))


### PR DESCRIPTION
## Summary
- define `ITEM_TYPES` for all equipment slots
- use a combobox in `item_manager_gui` for selecting item type

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886300816848328b90349f6dea32667