### PR TITLE
Disallow items from modifying talent point stats

### DIFF
--- a/dps_with_items.py
+++ b/dps_with_items.py
@@ -4,8 +4,13 @@ from item_database import get_items
 from dps_calculator import calculate_dps, WarriorStats
 
 
+IGNORED_ITEM_STATS = {"dual_wield_spec", "impale"}
+
+
 def merge_stats(base: Dict[str, float], item_stats: Dict[str, float]) -> None:
     for k, v in item_stats.items():
+        if k in IGNORED_ITEM_STATS:
+            continue
         base[k] = base.get(k, 0) + v
 
 

--- a/item_manager.py
+++ b/item_manager.py
@@ -14,8 +14,6 @@ STAT_KEYS: List[str] = [
     "base_speed_mh",
     "base_damage_oh",
     "base_speed_oh",
-    "dual_wield_spec",
-    "impale",
 ]
 
 # Predefined item types for each equipment slot. These strings are used when


### PR DESCRIPTION
## Summary
- stop exposing dual_wield_spec and impale fields when creating items
- ignore any dual_wield_spec or impale values that may exist on stored items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcf4deced4832898f3ec62f71d63a8