### PR TITLE
Add controls to delete the SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ The first tab lets you enter target information, ability modifiers and select
 your equipment. Press **Calculate** to compute DPS and populate the warrior
 skills table.
 
-The "Item Manager" tab provides controls to initialise the SQLite database,
-insert new items and define their stats. Supported stat keys include attack
+The "Item Manager" tab provides controls to initialise or delete the SQLite
+database, insert new items and define their stats. Supported stat keys include attack
 power, hit, crit, aura crit, weapon damage and ability modifiers such as block
 value, rage, improved cleave ranks and bonus execute rage. Strength and agility
 will automatically convert into the relevant derived stats when items are
 loaded.
 
-The database file (`items.db`) is created automatically in the project
-directory when you first run the application or press **Initialize DB**.
+The database file (`items.db`) is created in the project directory when you
+press **Initialize DB**.


### PR DESCRIPTION
## Summary
- add a delete_db helper and guard the data accessors when the SQLite file is missing
- stop automatically initialising the database so it can be recreated from scratch
- expose a Delete DB button in the item manager and document the new behaviour

## Testing
- python3 -m compileall unified_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68deb805efd08328806c453842078c47